### PR TITLE
Add interactive demo

### DIFF
--- a/assets/jade/index.jade
+++ b/assets/jade/index.jade
@@ -22,6 +22,9 @@ block content
       a.button.button-secondary(href='http://github.com/level') View On Github
   .content(role='main')
 
+    section.demo.cf
+      iframe(src="http://requirebin.com/embed?gist=brycebaril/9573685" width="100%" height="610px" frameborder=0)
+
     section.features.cf
       //
          a href="http://twitter.com/leveldb" title="leveldb on Twitter" class="twitter">@leveldb</a 


### PR DESCRIPTION
This PR is intended as a starting point for how to get an interactive demo onto the site.

This commit alone gives a working solution but it has a couple of downsides:
1. Because it is an iframe, sizing it vertically is problematic
2. Because it is an iframe, there is no graceful degradation if RequireBin goes down

My inclination is to convert this RequireBin demo into a module that can create a little bundle that can be just included directly into this package at which point it is just a div and both of the above are solved.

That said, I'm still not sure what the best strategy is for making that module, so I don't know the timeframe.

In terms of demos, I figured after demoing the basic levelup interface, we should showcase a couple of common modules (e.g. sublevel or level-version).

Thoughts?
