### PR TITLE
Fix leveldb.org link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # leveldb.org
 
-This is the source code for [leveldb.org](leveldb.org).
+This is the source code for [leveldb.org](http://leveldb.org).
 
 ## Stylus Structure
 The Stylus files are located under `assets/static/styl`, with the following architecture...


### PR DESCRIPTION
Was using a relative url, which results in links like https://github.com/Level/leveldb.org/blob/master/leveldb.org, instead of http://leveldb.org.
