### PR TITLE
Add Python bindings (Plyvel) link

### DIFF
--- a/assets/jade/index.jade
+++ b/assets/jade/index.jade
@@ -25,6 +25,7 @@ block content
       h3 LevelDB is a light-weight, single-purpose library for persistence with bindings to many platforms.
       a(href='https://github.com/google/leveldb', class='button button-primary button-large', title='C++ Library') C++ Library
       a(href='https://github.com/rvagg/node-levelup', class='button button-primary button-large', title='Node.js Bindings') Node.js Bindings
+      a(href='https://plyvel.readthedocs.org/', class='button button-primary button-large', title='Python Bindings (Plyvel)') Python Bindings (Plyvel)
 
     section.features.centered
       h3 Features

--- a/assets/jade/index.jade
+++ b/assets/jade/index.jade
@@ -24,8 +24,8 @@ block content
       h1 LevelDB
       h3 LevelDB is a light-weight, single-purpose library for persistence with bindings to many platforms.
       a(href='https://github.com/google/leveldb', class='button button-primary button-large', title='C++ Library') C++ Library
-      a(href='https://github.com/rvagg/node-levelup', class='button button-primary button-large', title='Node.js Bindings') Node.js Bindings
-      a(href='https://plyvel.readthedocs.org/', class='button button-primary button-large', title='Python Bindings (Plyvel)') Python Bindings (Plyvel)
+      a(href='https://github.com/rvagg/node-levelup', class='button button-primary button-large', title='LevelUP (Node.js)') LevelUP (Node.js)
+      a(href='https://plyvel.readthedocs.org/', class='button button-primary button-large', title='Plyvel (Python)') Plyvel (Python)
 
     section.features.centered
       h3 Features


### PR DESCRIPTION
This adds a button that links to Plyvel, a very comprehensive Python binding
for LevelDB, and shows it right next to the existing C++ and Node.js buttons.

Additional information:

* Documentation: https://plyvel.readthedocs.org/
* Github: https://github.com/wbolster/plyvel

Disclosure: I'm the author of Plyvel.