### PR TITLE
Typo fixes in index.jade

### DIFF
--- a/assets/jade/index.jade
+++ b/assets/jade/index.jade
@@ -37,7 +37,7 @@ block content
           p By default, LevelDB stores entries lexicographically sorted by keys. The sorting is one of the main distinguishing features of LevelDB amongst similar embedded data storage libraries and comes in very useful for querying as we’ll see later.
 
           h4 Arbitrary byte arrays
-          p Both keys and values are treated as simple arrays of bytes, so content can anything from ASCII strings to binary blobs.
+          p Both keys and values are treated as simple arrays of bytes, so content can be anything from ASCII strings to binary blobs.
 
           h4 Compressed storage
           p Google’s Snappy compression library is an optional dependency that can decrease the on-disk size of LevelDB stores with minimal sacrifice of speed. Snappy is highly optimized for fast compression and therefore does not provide particularly high compression ratios on common data.
@@ -60,7 +60,7 @@ block content
 
         .column
           h4 Kernel-Like
-          p Most databases are mysterious black-boxs. LevelDB provides a highly transparent, light-weight foundation for you to compose higher-level features on top of.
+          p Most databases are mysterious black-boxes. LevelDB provides a highly transparent, light-weight foundation for you to compose higher-level features on top of.
         
       .cf
         .column


### PR DESCRIPTION
This change fixes 2 typos in `index.jade`