### PR TITLE
Fix typo in footer.jade

### DIFF
--- a/assets/jade/footer.jade
+++ b/assets/jade/footer.jade
@@ -1,5 +1,5 @@
 footer(role='contentinfo')
   .content
     p Built and maintained by <a href='https://github.com/orgs/Level/people'>the core team</a> with help of contributors. 
-    p <em>Free as in Freedom</em>. Most of modules licensed under <a href='http://opensource.org/licenses/MIT'>MIT</a>.
+    p <em>Free as in Freedom</em>. Most modules licensed under <a href='http://opensource.org/licenses/MIT'>MIT</a>.
     p: a(href='https://github.com/level') See on Github


### PR DESCRIPTION
Fixes a typo in `footer.jade`.

"Most of modules" -> "Most modules"