### PR TITLE
fix broken link

### DIFF
--- a/assets/jade/index.jade
+++ b/assets/jade/index.jade
@@ -149,7 +149,7 @@ block content
       .cf
 
         .column.column-small
-          a(href='http://dailyjs.com/2013/04/18/leveldb-and-node-1/') Intro to LevelDB
+          a(href='http://web.archive.org/web/20130502222338/http://dailyjs.com/2013/04/19/leveldb-and-node-1/') Intro to LevelDB
           p Rodd Vagg
 
         .column.column-small


### PR DESCRIPTION
Redirect broken link http://dailyjs.com/2013/04/19/leveldb-and-node-1/ to the archive.org's WayBack machine of May 2013.